### PR TITLE
Log file path instead of file name

### DIFF
--- a/__tests__/json-file-reader.test.ts
+++ b/__tests__/json-file-reader.test.ts
@@ -2,13 +2,13 @@ import { getJson } from '../src/json-file-reader';
 import excepted from './mocks/tested-data/valid.json';
 import { InvalidJsonFileError } from '../src/errors';
 
-const mocks_dir = './__tests__/mocks';
+const mocks_dir = '__tests__/mocks';
 
 describe('Process a JSON file', () => {
     test('should return a valid JSON when procesings valid JSON file', async () => {
-        const validJsonFile = 'tested-data/valid.json';
+        const validJsonFile = `${mocks_dir}/tested-data/valid.json`;
 
-        const result = await getJson(mocks_dir, validJsonFile);
+        const result = await getJson(validJsonFile);
         expect(typeof result).toBe('object');
 
         Object.keys(excepted).forEach(key => {
@@ -18,27 +18,27 @@ describe('Process a JSON file', () => {
     });
 
     test('should throw an error when procesing invalid JSON file', async () => {
-        const invalidJsonFile = 'tested-data/invalid_by_format.json';
+        const invalidJsonFile = `${mocks_dir}/tested-data/invalid_by_format.json`;
 
-        const task = getJson(mocks_dir, invalidJsonFile);
+        const task = getJson(invalidJsonFile);
 
         try {
             expect(await task).toThrowError(InvalidJsonFileError);
         } catch (e) {
             const err = e as InvalidJsonFileError;
-            expect(err.fileName).toEqual('invalid_by_format.json');
+            expect(err.filePath).toEqual(invalidJsonFile);
         }
     });
 
     test("should throw an error when file or directory don't exist", async () => {
-        const notExistingFile = 'no_such_file.json';
+        const notExistingFile = `${mocks_dir}/no_such_file.json`;
 
-        const task = getJson(mocks_dir, notExistingFile);
+        const task = getJson(notExistingFile);
         try {
             expect(await task).toThrowError(InvalidJsonFileError);
         } catch (e) {
             const err = e as InvalidJsonFileError;
-            expect(err.fileName).toEqual('no_such_file.json');
+            expect(err.filePath).toEqual(notExistingFile);
             expect(typeof err.innerError).not.toBeUndefined();
             expect((<object>err.innerError)['code']).toBe('ENOENT');
         }

--- a/__tests__/json-validator.test.ts
+++ b/__tests__/json-validator.test.ts
@@ -6,13 +6,13 @@ const invalidSchemaFile = `schema/invalid.json`;
 const validDataFile = `tested-data/valid.json`;
 const invalidDataFile = `tested-data/invalid_by_schema.json`;
 
-const mocks_dir = './__tests__/mocks';
+const mocks_dir = '__tests__/mocks';
 
 describe('Json validation results', () => {
     test('all successful when all jsons in the list are valid', async () => {
         const results = await validateJsons(mocks_dir, validSchemaFile, [validDataFile, validDataFile]);
         expect(results.every(r => r.valid)).toBeTruthy();
-        expect(results.every(r => r.fileName === 'valid.json')).toBeTruthy();
+        expect(results.every(r => r.filePath === `${mocks_dir}/${validDataFile}`)).toBeTruthy();
     });
 
     test('only one failure when one json in the list is invalid', async () => {
@@ -20,31 +20,31 @@ describe('Json validation results', () => {
 
         const successes = results.filter(r => r.valid);
         expect(successes.length).toEqual(1);
-        expect(successes.every(r => r.fileName === 'valid.json')).toBeTruthy();
+        expect(successes.every(r => r.filePath === `${mocks_dir}/${validDataFile}`)).toBeTruthy();
 
         const failures = results.filter(r => !r.valid);
         expect(failures.length).toEqual(1);
-        expect(failures.every(r => r.fileName === 'invalid_by_schema.json')).toBeTruthy();
+        expect(failures.every(r => r.filePath === `${mocks_dir}/${invalidDataFile}`)).toBeTruthy();
     });
 
     test('all failures when all jsons in the list are invalid', async () => {
         const results = await validateJsons(mocks_dir, validSchemaFile, [invalidDataFile, invalidDataFile]);
         expect(results.every(r => !r.valid)).toBeTruthy();
-        expect(results.every(r => r.fileName === 'invalid_by_schema.json')).toBeTruthy();
+        expect(results.every(r => r.filePath === `${mocks_dir}/${invalidDataFile}`)).toBeTruthy();
     });
 
     test('one failures when schema file are invalid', async () => {
         const results = await validateJsons(mocks_dir, invalidSchemaFile, [validDataFile, validDataFile]);
         expect(results).toHaveLength(1);
         expect(results.every(r => !r.valid)).toBeTruthy();
-        expect(results.every(r => r.fileName === 'invalid.json')).toBeTruthy();
+        expect(results.every(r => r.filePath === `${mocks_dir}/${invalidSchemaFile}`)).toBeTruthy();
     });
 
     test('one failure when no schema file', async () => {
         const results = await validateJsons(mocks_dir, '', [validDataFile, validDataFile]);
         expect(results).toHaveLength(1);
         expect(results.every(r => !r.valid)).toBeTruthy();
-        expect(results.every(r => r.fileName === 'schema')).toBeTruthy();
+        expect(results.every(r => r.filePath === mocks_dir)).toBeTruthy();
     });
 
     test('empty when when no jsons in the list', async () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,9 +2,9 @@ interface ValidationError {}
 
 export class InvalidJsonFileError extends Error implements ValidationError {
     public filePath: string;
-    public innerError?: Error | object;
+    public innerError: Error | object;
 
-    constructor(filePath: string, innerError?: Error | object) {
+    constructor(filePath: string, innerError: Error | object) {
         super();
         this.innerError = innerError;
         this.filePath = filePath;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,13 +1,13 @@
 interface ValidationError {}
 
 export class InvalidJsonFileError extends Error implements ValidationError {
-    public fileName: string;
+    public filePath: string;
     public innerError?: Error | object;
 
-    constructor(fileName: string, innerError?: Error | object) {
+    constructor(filePath: string, innerError?: Error | object) {
         super();
         this.innerError = innerError;
-        this.fileName = fileName;
+        this.filePath = filePath;
     }
 }
 

--- a/src/json-file-reader.ts
+++ b/src/json-file-reader.ts
@@ -1,15 +1,12 @@
 import fs from 'fs';
-import path from 'path';
 import { InvalidJsonFileError } from './errors';
 
-export const getJson = async (repoDir: string, fileRelativePath: string): Promise<object> => {
-    const fileName = path.basename(fileRelativePath);
+export const getJson = async (filePath: string): Promise<object> => {
     try {
-        const filePath = path.join(repoDir, fileRelativePath);
         const fileContents = await fs.promises.readFile(filePath, { encoding: 'utf-8' });
         const json = JSON.parse(fileContents);
         return json;
     } catch (ex) {
-        throw new InvalidJsonFileError(fileName, ex);
+        throw new InvalidJsonFileError(filePath, ex);
     }
 };

--- a/src/json-validator.ts
+++ b/src/json-validator.ts
@@ -4,7 +4,7 @@ import { schemaValidator } from './schema-validator';
 import { prettyLog } from './logger';
 
 export interface ValidationResult {
-    fileName: string;
+    filePath: string;
     valid: boolean;
 }
 
@@ -13,25 +13,25 @@ export const validateJsons = async (
     schemaRelativePath: string,
     jsonRelativePaths: string[]
 ): Promise<ValidationResult[]> => {
+    const schemaPath = path.join(sourceDir, schemaRelativePath);
     try {
-        const schema = await getJson(sourceDir, schemaRelativePath);
+        const schema = await getJson(schemaPath);
         const validatorFunc = await schemaValidator.prepareSchema(schema);
         return await Promise.all(
             jsonRelativePaths.map(async relativePath => {
-                const fileName = path.basename(relativePath);
+                const filePath = path.join(sourceDir, relativePath);
                 try {
-                    const jsonData = await getJson(sourceDir, relativePath);
+                    const jsonData = await getJson(filePath);
                     const result = await schemaValidator.validate(jsonData, validatorFunc);
-                    return { fileName, valid: result };
+                    return { filePath, valid: result };
                 } catch (e) {
-                    prettyLog(fileName, e);
-                    return { fileName, valid: false };
+                    prettyLog(filePath, e);
+                    return { filePath, valid: false };
                 }
             })
         );
     } catch (err) {
-        const schemaFileName = path.basename(schemaRelativePath);
-        prettyLog(schemaFileName, err);
-        return [{ fileName: schemaFileName || 'schema', valid: false }];
+        prettyLog(schemaPath, err);
+        return [{ filePath: schemaPath, valid: false }];
     }
 };

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import { InvalidSchemaError, InvalidJsonError, InvalidJsonFileError } from './errors';
 
-export const prettyLog = (fileName: string, error?: Error): void => {
-    const prettyFileName = chalk`{grey {bold {underline ${fileName}}}}\n`;
+export const prettyLog = (filePath: string, error?: Error): void => {
+    const prettyFilePath = chalk`{grey {bold {underline ${filePath}}}}`;
     const prettyMessagePrefix = error ? chalk`{red {bold ✗}} ` : chalk`{green {bold ✓}} `;
-    let output = `${prettyMessagePrefix}${prettyFileName}`;
+    let output = `${prettyMessagePrefix}${prettyFilePath}\n`;
     switch (true) {
         case error instanceof InvalidSchemaError:
             const schemaErr = error as InvalidSchemaError;
@@ -17,16 +17,14 @@ export const prettyLog = (fileName: string, error?: Error): void => {
         case error instanceof InvalidJsonFileError:
             const fileErr = error as InvalidJsonFileError;
             const reason =
-                fileErr.innerError === undefined
-                    ? ''
-                    : fileErr.innerError instanceof Error
+                fileErr.innerError instanceof Error
                     ? `${fileErr.innerError.name}${fileErr.innerError.message}`
                     : fileErr.innerError || '';
             output = `${output}${reason}`;
             break;
         case error instanceof Error:
-            const err = error as InvalidJsonError;
-            output = output.concat(err.message || '');
+            const err = error as Error;
+            output = `${output}${err.name} - ${err.message}\n${err.stack}`;
             break;
         default:
             break;

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ async function run() {
             jsonRelativePaths
         );
 
-        const invalidJsons = validationResults.filter(res => !res.valid).map(res => res.fileName);
+        const invalidJsons = validationResults.filter(res => !res.valid).map(res => res.filePath);
 
         core.setOutput('INVALID', invalidJsons.length > 0 ? invalidJsons.join(',') : '');
 


### PR DESCRIPTION
Logging the file path instead of the file name will make it more clear to understand which file failed to validate.