### PR TITLE
Handle missing configuration edge cases

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -7,7 +7,7 @@ import { MockedConfig } from './mocks/mocked-config';
 let mockedConfig: MockedConfig;
 let ip: string;
 
-describe('Run tests', () => {
+describe('Github action results', () => {
     beforeEach(() => {
         ip = path.join(__dirname, '..', 'lib', 'main.js');
         mockedConfig = new MockedConfig();
@@ -19,8 +19,27 @@ describe('Run tests', () => {
         jest.resetAllMocks();
     });
 
-    test('All inputs are set and valid', () => {
+    test('No errors when all inputs are set and valid', () => {
         // Arrange
+        mockedConfig.mockValue('SCHEMA', './mocks/schema/valid.json');
+        mockedConfig.mockValue('JSONS', './mocks/tested-data/valid.json');
+
+        mockedConfig.set();
+
+        const options: cp.ExecOptions = {
+            env: process.env,
+        };
+
+        // Act
+        const result = cp.execSync(`node ${ip}`, options);
+
+        // Assert
+        expect(result.toString()).toContain(`::set-output name=INVALID,::${os.EOL}`);
+    });
+
+    test('Error is thrown when GITHUB_WORKSPACE environment variable is not set', () => {
+        // Arrange
+        mockedConfig.resetAll();
         mockedConfig.mockValue('SCHEMA', './mocks/schema/valid.json');
         mockedConfig.mockValue('JSONS', './mocks/tested-data/valid.json');
 
@@ -32,12 +51,149 @@ describe('Run tests', () => {
 
         try {
             // Act
-            const result = cp.execSync(`node ${ip}`, options);
-
-            // Assert
-            expect(result.toString()).toContain(`::set-output name=INVALID,::${os.EOL}`);
+            cp.execSync(`node ${ip}`, options);
         } catch (ex) {
-            expect(ex).toBeUndefined();
+            // Assert
+            expect(ex).not.toBeUndefined();
+            expect(ex.output).not.toBeUndefined();
+            expect(ex.output.toString()).toContain(`Missing GITHUB_WORKSPACE environment variable`);
+        }
+    });
+
+    test('Error is thrown when SCHEMA input is not set', () => {
+        // Arrange
+        mockedConfig.mockValue('JSONS', './mocks/tested-data/valid.json');
+
+        mockedConfig.set();
+
+        const options: cp.ExecOptions = {
+            env: process.env,
+        };
+
+        try {
+            // Act
+            cp.execSync(`node ${ip}`, options);
+        } catch (ex) {
+            // Assert
+            expect(ex).not.toBeUndefined();
+            expect(ex.output).not.toBeUndefined();
+            expect(ex.output.toString()).toContain(`Missing SCHEMA input`);
+        }
+    });
+
+    test('Error is thrown when JSONS input is not set', () => {
+        // Arrange
+        mockedConfig.mockValue('SCHEMA', './mocks/schema/valid.json');
+
+        mockedConfig.set();
+
+        const options: cp.ExecOptions = {
+            env: process.env,
+        };
+
+        try {
+            // Act
+            cp.execSync(`node ${ip}`, options);
+        } catch (ex) {
+            // Assert
+            expect(ex).not.toBeUndefined();
+            expect(ex.output).not.toBeUndefined();
+            expect(ex.output.toString()).toContain(`Missing JSONS input`);
+        }
+    });
+
+    test('Error is thrown when GITHUB_WORKSPACE environment variable is empty', () => {
+        // Arrange
+        mockedConfig.resetAll();
+        mockedConfig.mockValue('GITHUB_WORKSPACE', '');
+        mockedConfig.mockValue('SCHEMA', './mocks/schema/valid.json');
+        mockedConfig.mockValue('JSONS', './mocks/tested-data/valid.json');
+
+        mockedConfig.set();
+
+        const options: cp.ExecOptions = {
+            env: process.env,
+        };
+
+        try {
+            // Act
+            cp.execSync(`node ${ip}`, options);
+        } catch (ex) {
+            // Assert
+            expect(ex).not.toBeUndefined();
+            expect(ex.output).not.toBeUndefined();
+            expect(ex.output.toString()).toContain(`Missing GITHUB_WORKSPACE environment variable`);
+            expect(ex.output.toString()).not.toContain(`Missing SCHEMA input`);
+            expect(ex.output.toString()).not.toContain(`Missing JSONS input`);
+        }
+    });
+
+    test('Error is thrown when SCHEMA input is empty', () => {
+        // Arrange
+        mockedConfig.mockValue('SCHEMA', '');
+        mockedConfig.mockValue('JSONS', './mocks/tested-data/valid.json');
+
+        mockedConfig.set();
+
+        const options: cp.ExecOptions = {
+            env: process.env,
+        };
+
+        try {
+            // Act
+            cp.execSync(`node ${ip}`, options);
+        } catch (ex) {
+            // Assert
+            expect(ex).not.toBeUndefined();
+            expect(ex.output).not.toBeUndefined();
+            expect(ex.output.toString()).toContain(`Missing SCHEMA input`);
+            expect(ex.output.toString()).not.toContain(`Missing JSONS input`);
+        }
+    });
+
+    test('Error is thrown when JSONS input is empty', () => {
+        // Arrange
+        mockedConfig.mockValue('SCHEMA', './mocks/schema/valid.json');
+        mockedConfig.mockValue('JSONS', '');
+
+        mockedConfig.set();
+
+        const options: cp.ExecOptions = {
+            env: process.env,
+        };
+
+        try {
+            // Act
+            cp.execSync(`node ${ip}`, options);
+        } catch (ex) {
+            // Assert
+            expect(ex).not.toBeUndefined();
+            expect(ex.output).not.toBeUndefined();
+            expect(ex.output.toString()).not.toContain(`Missing SCHEMA input`);
+            expect(ex.output.toString()).toContain(`Missing JSONS input`);
+        }
+    });
+
+    test('Error is thrown when both SCHEMA and JSONS inputs are empty', () => {
+        // Arrange
+        mockedConfig.mockValue('SCHEMA', '');
+        mockedConfig.mockValue('JSONS', '');
+
+        mockedConfig.set();
+
+        const options: cp.ExecOptions = {
+            env: process.env,
+        };
+
+        try {
+            // Act
+            cp.execSync(`node ${ip}`, options);
+        } catch (ex) {
+            // Assert
+            expect(ex).not.toBeUndefined();
+            expect(ex.output).not.toBeUndefined();
+            expect(ex.output.toString()).toContain(`Missing SCHEMA input`);
+            expect(ex.output.toString()).toContain(`Missing JSONS input`);
         }
     });
 });

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,9 +1,9 @@
 import * as core from '@actions/core';
 
 export enum ConfigKey {
-    GITHUB_WORKSPACE,
-    SCHEMA,
-    JSONS,
+    GITHUB_WORKSPACE = 'GITHUB_WORKSPACE',
+    SCHEMA = 'SCHEMA',
+    JSONS = 'JSONS',
 }
 
 export type ConfigKeys = keyof typeof ConfigKey;
@@ -45,4 +45,17 @@ export function getConfig(): Config {
         config[ConfigKey[i.key]] = value;
     });
     return config as Config;
+}
+
+export function verifyConfigValues(config: Config): string[] | undefined {
+    let errors: string[] = [];
+    Object.keys(config).forEach(key => {
+        if (config[key] === '') {
+            const mapping = configMapping.find(i => i.key === key);
+            errors.push(
+                `🚨 Missing ${key} ${mapping!.setup === 'ENV' ? 'environment variable' : mapping!.setup.toLowerCase()}`
+            );
+        }
+    });
+    return errors.length > 0 ? errors : undefined;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,18 @@
 import * as core from '@actions/core';
-import { getConfig } from './configuration';
+import { getConfig, verifyConfigValues } from './configuration';
 import { validateJsons } from './json-validator';
 
 async function run() {
     try {
         const configuration = getConfig();
-        const jsonRelativePaths = configuration.JSONS === '' ? [] : configuration.JSONS.split(',');
+        const configurationErrors = verifyConfigValues(configuration);
+        if (configurationErrors) {
+            configurationErrors.forEach(e => core.error(e));
+            core.setFailed('Missing configuration');
+            return;
+        }
+
+        const jsonRelativePaths = configuration.JSONS.split(',');
 
         const validationResults = await validateJsons(
             configuration.GITHUB_WORKSPACE,

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { validateJsons } from './json-validator';
 async function run() {
     try {
         const configuration = getConfig();
-        const jsonRelativePaths = configuration.JSONS.split(',');
+        const jsonRelativePaths = configuration.JSONS === '' ? [] : configuration.JSONS.split(',');
 
         const validationResults = await validateJsons(
             configuration.GITHUB_WORKSPACE,


### PR DESCRIPTION
Any missing configuration (`GITHUB_WORKSPACE`, `SCHEMA`, `JSONS`) will make the action fail. 

- [x] Meaningful logs
- [x] Unit tests 